### PR TITLE
Env changes 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "npm run serve:ssr",
-    "build": "ng build --prod --aot --output-hashing=all",
+    "build": "ng build --configuration production --aot --output-hashing=all",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "npm run serve:ssr",
-    "build": "ng build --configuration production --aot --output-hashing=all",
+    "build": "ng build --configuration=production --aot --output-hashing=all",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: false
+};


### PR DESCRIPTION
`--prod` [appears](https://angular.io/cli/build) to be deprecated.

Adds default environment.ts file, should be overwritten when `npm build` is run.